### PR TITLE
Ignore glyph if font does not contain it

### DIFF
--- a/src/EasySVG.php
+++ b/src/EasySVG.php
@@ -244,6 +244,11 @@ class EasySVG {
 
             $letter = $text[$i];
 
+            //ignore this glyph instead of throwing an error if font does not define it
+            if (!array_key_exists($letter, $this->font->glyphs)) {
+		        continue;
+	        }
+            
             // line break support (10 is unicode for linebreak)
             if($letter==10){
                 $horizAdvX = 0;
@@ -288,6 +293,11 @@ class EasySVG {
 
             $letter = $text[$i];
 
+            //ignore this glyph instead of throwing and error if font does not define it
+            if (!array_key_exists($letter, $this->font->glyphs)) {
+		        continue;
+	        }            
+            
             // line break support (10 is unicode for linebreak)
             if($letter==10){
                 $width = $lineWidth>$width ? $lineWidth : $width;


### PR DESCRIPTION
Some fonts could be incomplete causing Undefined offset: errors to happen when finding elements from glyphs array. For example http://www.fontspace.com/kineticplasma-fonts/hussar-bold-web-edition causes 'Undefined offset: 132'